### PR TITLE
fixed left and right props of Input component.

### DIFF
--- a/template/src/components/molecules/input/index.tsx
+++ b/template/src/components/molecules/input/index.tsx
@@ -127,7 +127,7 @@ export default function ({
             style={{
               height: iconSize,
               position: 'absolute',
-              right: normalize(theme.spacing.small),
+              left: normalize(theme.spacing.small),
               top: (inputHeight - iconSize) / 2,
               width: iconSize
             }}
@@ -161,7 +161,7 @@ export default function ({
                 style={{
                   height: iconSize,
                   position: 'absolute',
-                  left: normalize(theme.spacing.small),
+                  right: normalize(theme.spacing.small),
                   top: (inputHeight - iconSize) / 2,
                   width: iconSize
                 }}


### PR DESCRIPTION
When we pass left props with a icon , it sits on the right side . Similarly  the left props would keep the component on right side . 
This commit fixes that issue.